### PR TITLE
chore: [MIL-86] deploy from branch only in dev env

### DIFF
--- a/.github/workflows/build-n-deploy-branch.yaml
+++ b/.github/workflows/build-n-deploy-branch.yaml
@@ -9,7 +9,6 @@ on:
         description: "Environment where to deploy"
         options:
           - dev-cd
-          - uat-cd
 env:
   TARGET_PLATFORMS: linux/arm64
 


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to remove the possibility to deploy in UAT from a feature branch. 

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The uat environment should be protected from feature branch deploy. The environment `uat-cd` has already been enforced to be accessed from main only.
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.